### PR TITLE
fix: Correct Gemini TTS function call from upload_audio to upload_tts…

### DIFF
--- a/backend/ai_model/tts_interactions.py
+++ b/backend/ai_model/tts_interactions.py
@@ -91,7 +91,7 @@ def get_gemini_output(tts_input, lang, model, gender):
         response = client.synthesize_speech(input=synthesis_input, voice=voice, audio_config=audio_config)
 
         audioBase64 = base64.b64encode(response.audio_content).decode("utf-8")
-        audio = upload_audio(audioBase64)
+        audio = upload_tts_audio(audioBase64)
         return audio
     except Exception as e:
         raise Exception(str(e))


### PR DESCRIPTION
- Fixed incomplete function rename in get_gemini_output() on line 94
- All TTS providers now consistently use upload_tts_audio()
- Resolves 'name upload_audio is not defined' error for Gemini TTS model